### PR TITLE
Fix misplaced closing brace in wstring.hpp

### DIFF
--- a/openvpn/common/wstring.hpp
+++ b/openvpn/common/wstring.hpp
@@ -88,5 +88,6 @@ inline std::wstring pack_string_vector(const std::vector<std::string> &strvec)
     return ret;
 }
 
+} // namespace openvpn::wstring
+
 #endif // #ifdef _WIN32
-}


### PR DESCRIPTION
## Summary
- close the `openvpn::wstring` namespace before the `_WIN32` guard ends

## Testing
- `cmake ..` *(fails: Could NOT find asio)*

------
https://chatgpt.com/codex/tasks/task_e_6840be5f106c8329848168b8e21c0220