### PR TITLE
Add host_port tests for illegal host characters

### DIFF
--- a/test/unittests/test_hostport.cpp
+++ b/test/unittests/test_hostport.cpp
@@ -65,4 +65,10 @@ TEST(misc, host_port)
     test("/foo/bar", "unix", false, "", "", 0, false);
     test("/foo/bar", "unix", true, "/foo/bar", "unix", 0, true);
     test("/foo/bar:unix", "", true, "/foo/bar", "unix", 0, true);
+
+    // Reject hosts with illegal characters
+    test("foo@bar", "1234", false, "", "", 0, false);
+    test("foo@bar:80", "", false, "", "", 0, false);
+    test("foo$bar", "1234", false, "", "", 0, false);
+    test("foo$bar:80", "", false, "", "", 0, false);
 }


### PR DESCRIPTION
## Summary
- cover invalid host characters in `HostPort::split_host_port`
- ensure new cases fail to parse using existing test helper

## Testing
- `ninja coreUnitTests`
- `./test/unittests/coreUnitTests --gtest_filter=misc.host_port`
- `./test/unittests/coreUnitTests` *(fails to show final lines but exits with success)*

------
https://chatgpt.com/codex/tasks/task_e_6840c1641ac08329a6e36fa528d55763