### PR TITLE
Fix return_eof_on_empty init in datagram BIO

### DIFF
--- a/openvpn/openssl/bio/bio_memq_dgram.hpp
+++ b/openvpn/openssl/bio/bio_memq_dgram.hpp
@@ -115,7 +115,7 @@ inline int memq_new(BIO *b)
         return 0;
     BIO_set_shutdown(b, 1);
     BIO_set_init(b, 1);
-    b->return_eof_on_empty = false;
+    bmq->return_eof_on_empty = false;
     BIO_set_data(b, (void *)bmq);
     return 1;
 }


### PR DESCRIPTION
## Summary
- fix initialization of return_eof_on_empty in memq_new

## Testing
- `cmake -GNinja ..`
- `cmake --build . -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6840c162112c8329b0c78058724c9546